### PR TITLE
Update Lambda Runtime Version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ module "lambda" {
 
   handler                        = "notify_slack.lambda_handler"
   source_path                    = "${path.module}/functions/notify_slack.py"
-  runtime                        = "python3.8"
+  runtime                        = var.lambda_runtime
   timeout                        = 30
   kms_key_arn                    = var.kms_key_arn
   reserved_concurrent_executions = var.reserved_concurrent_executions

--- a/variables.tf
+++ b/variables.tf
@@ -161,3 +161,8 @@ variable "subscription_filter_policy" {
   type        = string
   default     = null
 }
+
+variable "lambda_runtime" {
+  type    = string
+  default = "python3.11"
+}


### PR DESCRIPTION
Upgraded Lambda runtime environment to Python 3.11
Added a new variable lambda_runtime to represent the Python runtime version within the Lambda function.