### PR TITLE
Remove deprecated __future__ imports

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from urllib.error import HTTPError
 import os, boto3, json, base64
 import urllib.request, urllib.parse


### PR DESCRIPTION
Many older codebases have `__future__` imports for forwards compatibility with features. As of this writing, all but one of those features is now stable in all currently supported versions of Python and so the imports are no longer needed. While such imports are harmless, they are also unnecessary and in most cases you probably just forgot to remove them. 

This codemod removes all such `__future__` imports, preserving only those that are still necessary for forwards compatibility. 

Our changes look like the following:
```diff
 import os
-from __future__ import print_function

 print("HELLO")
```

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/library/__future__.html](https://docs.python.org/3/library/__future__.html)
</details>

🧚🤖Powered by Pixeebot (codemod ID: [pixee:python/remove-future-imports](https://docs.pixee.ai/codemods/python/pixee_python_remove-future-imports)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fterraform-aws-notify-slack%7C3c5f248a8f49aeb41d709fa62978b972bbef7d9f)

<!--{"type":"DRIP","codemod":"pixee:python/remove-future-imports"}-->